### PR TITLE
Keep only Config UI language and SSL from config.json

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Lint the project
         run: npm run lint
 
+      - name: Test the project
+        run: npm test
+
       - name: Build the project
         run: npm run build
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "i18n:merge": "node --import tsx ./scripts/i18n-merge.ts",
     "i18n:missing": "node --import tsx ./scripts/i18n-missing.ts",
     "lint": "eslint . --fix --max-warnings=0",
+    "test": "node --import tsx --test src/tools/config-ui.test.ts",
     "postinstall": "patch-package",
     "prepublishOnly": "npm run lint && npm run build"
   },

--- a/src/homebridge/platform.ts
+++ b/src/homebridge/platform.ts
@@ -16,6 +16,7 @@ import { History } from '../model/history.js';
 import { DummyConfig, DummyPlatformConfig, GroupConfig, HomeKitAccessory } from '../model/types.js';
 import { WebhookManager } from '../model/webhook.js';
 
+import { readConfigUiSettings } from '../tools/config-ui.js';
 import { Log } from '../tools/log.js';
 import { Storage } from '../tools/storage.js';
 import { printableValues } from '../tools/validation.js';
@@ -38,10 +39,17 @@ export class HomebridgeDummyPlatform implements DynamicPlatformPlugin {
     private readonly api: API,
   ) {
 
-    setLanguage(api.user.configPath());
+    const configPath = api.user.configPath();
+    const configUi = readConfigUiSettings(configPath);
+    setLanguage(configUi.language);
 
     this.log = new Log(logger, config.verbose === true);
-    this.webhookManager = new WebhookManager(this.log, this.api.user.configPath(), { port: config.webhookPort, ...config.webhookConfig });
+    this.webhookManager = new WebhookManager(
+      this.log,
+      configPath,
+      { port: config.webhookPort, ...config.webhookConfig },
+      configUi.ssl,
+    );
     this.conditionManager = new ConditionManager(this.log, api.user.storagePath());
 
     this.log.ifVerbose(

--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -1,4 +1,3 @@
-import { readFileSync } from 'fs';
 import merge from 'lodash.merge';
 
 import de from './de.js';
@@ -38,16 +37,9 @@ export function getStrings(language: Language): Translation {
 
 export let strings: Translation = en;
 
-export function setLanguage(configPath: string) {
+export function setLanguage(language?: string) {
 
-  let isoLang: string | undefined;
-  try {
-    const systemConfig = readFileSync(configPath, { encoding: 'utf8' });
-    isoLang = JSON.parse(systemConfig).platforms.filter( (c: Record<string, unknown>) => c.platform === 'config')[0].lang;
-  } catch {
-    // nothing
-  }
-
+  let isoLang = language;
   if (isoLang === undefined || isoLang.trim().length === 0 || isoLang === 'auto') {
     isoLang = Intl.DateTimeFormat().resolvedOptions().locale.split('-')[0];
   }

--- a/src/model/webhook.ts
+++ b/src/model/webhook.ts
@@ -3,7 +3,6 @@ import { readFileSync } from 'fs';
 import { CharacteristicValue } from 'homebridge';
 import { Server } from 'http';
 import { createServer, ServerOptions } from 'https';
-import path from 'path';
 
 import { DummyAccessory } from '../accessory/base.js';
 
@@ -12,6 +11,7 @@ import { DummyConfig, WebhookConfig } from './types.js';
 
 import { strings } from '../i18n/i18n.js';
 
+import { ConfigUiSsl, resolveConfigUiSsl } from '../tools/config-ui.js';
 import { Log } from '../tools/log.js';
 import { toPrimitive } from '../tools/primitive.js';
 import { assert } from '../tools/validation.js';
@@ -70,24 +70,12 @@ export class WebhookManager {
     private readonly log: Log,
     configPath: string,
     private readonly config: WebhookConfig = {},
+    configUiSsl?: ConfigUiSsl,
   ) {
 
-    try {
-      const systemConfig = readFileSync(configPath, { encoding: 'utf8' });
-      const systemSSLConfig = JSON.parse(systemConfig).platforms.filter( (c: Record<string, string>) => c.platform === 'config')[0].ssl;
-
-      if (systemSSLConfig !== undefined) {
-
-        if (systemSSLConfig.selfSigned === true) {
-          systemSSLConfig.key = systemSSLConfig.key ?? path.join(configPath, '../ssl-certs/private-key.pem');
-          systemSSLConfig.cert = systemSSLConfig.cert ?? path.join(configPath, '../ssl-certs/certificate.pem');
-        }
-
-        this.config = { ...systemSSLConfig , ...this.config };
-      }
-
-    } catch {
-      // Nothing
+    const inheritedSsl = resolveConfigUiSsl(configUiSsl, configPath);
+    if (inheritedSsl !== undefined) {
+      this.config = { ...inheritedSsl, ...this.config };
     }
 
     this.config.port = this.config.port ?? DEFAULT_PORT;

--- a/src/tools/config-ui.test.ts
+++ b/src/tools/config-ui.test.ts
@@ -1,0 +1,132 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { describe, it } from 'node:test';
+
+import { extractConfigUiSettings, readConfigUiSettings, resolveConfigUiSsl } from './config-ui.js';
+
+const HOMEBRIDGE_CONFIG = JSON.stringify({
+  bridge: {
+    name: 'Homebridge',
+    username: 'AA:BB:CC:DD:EE:FF',
+    pin: '031-45-154',
+  },
+  platforms: [
+    {
+      platform: 'Nest',
+      password: 'nest-secret',
+      googleAuth: {
+        cookies: 'cookie-secret',
+        issueToken: 'https://example.invalid/token',
+      },
+    },
+    {
+      platform: 'config',
+      lang: 'de',
+      token: 'config-ui-token',
+      ssl: {
+        key: '/etc/ssl/key.pem',
+        cert: '/etc/ssl/cert.pem',
+        extra: 'not-used',
+      },
+    },
+  ],
+  accessories: [
+    {
+      accessory: 'OtherPlugin',
+      key: 'accessory-secret',
+    },
+  ],
+});
+
+describe('extractConfigUiSettings', () => {
+  it('returns only Config UI language and SSL', () => {
+    assert.deepEqual(extractConfigUiSettings(HOMEBRIDGE_CONFIG), {
+      language: 'de',
+      ssl: {
+        key: '/etc/ssl/key.pem',
+        cert: '/etc/ssl/cert.pem',
+      },
+    });
+  });
+
+  it('does not keep other plugins, bridge, or accessory secrets', () => {
+    const serialized = JSON.stringify(extractConfigUiSettings(HOMEBRIDGE_CONFIG));
+
+    assert.equal(serialized.includes('nest-secret'), false);
+    assert.equal(serialized.includes('cookie-secret'), false);
+    assert.equal(serialized.includes('031-45-154'), false);
+    assert.equal(serialized.includes('AA:BB:CC:DD:EE:FF'), false);
+    assert.equal(serialized.includes('accessory-secret'), false);
+    assert.equal(serialized.includes('config-ui-token'), false);
+    assert.equal(serialized.includes('not-used'), false);
+  });
+
+  it('returns empty settings for invalid JSON', () => {
+    assert.deepEqual(extractConfigUiSettings('{'), {});
+  });
+
+  it('returns empty settings when Config UI is missing', () => {
+    assert.deepEqual(extractConfigUiSettings(JSON.stringify({
+      platforms: [{ platform: 'Nest', password: 'nest-secret' }],
+    })), {});
+  });
+
+  it('keeps passphrase and pfx when present', () => {
+    assert.deepEqual(extractConfigUiSettings(JSON.stringify({
+      platforms: [{
+        platform: 'config',
+        ssl: {
+          pfx: '/certs/homebridge.pfx',
+          passphrase: 'pfx-pass',
+          selfSigned: false,
+        },
+      }],
+    })), {
+      ssl: {
+        pfx: '/certs/homebridge.pfx',
+        passphrase: 'pfx-pass',
+        selfSigned: false,
+      },
+    });
+  });
+});
+
+describe('readConfigUiSettings', () => {
+  it('reads language from a config file', () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'homebridge-dummy-'));
+    const configPath = path.join(dir, 'config.json');
+    writeFileSync(configPath, HOMEBRIDGE_CONFIG);
+
+    assert.equal(readConfigUiSettings(configPath).language, 'de');
+  });
+
+  it('returns empty settings when the file is missing', () => {
+    assert.deepEqual(readConfigUiSettings(path.join(tmpdir(), 'homebridge-dummy-missing', 'config.json')), {});
+  });
+});
+
+describe('resolveConfigUiSsl', () => {
+  it('fills default self-signed cert paths', () => {
+    const configPath = '/var/lib/homebridge/config.json';
+
+    assert.deepEqual(resolveConfigUiSsl({ selfSigned: true }, configPath), {
+      selfSigned: true,
+      key: path.join(configPath, '../ssl-certs/private-key.pem'),
+      cert: path.join(configPath, '../ssl-certs/certificate.pem'),
+    });
+  });
+
+  it('leaves explicit cert paths in place', () => {
+    assert.deepEqual(resolveConfigUiSsl({
+      selfSigned: true,
+      key: '/custom/key.pem',
+      cert: '/custom/cert.pem',
+    }, '/var/lib/homebridge/config.json'), {
+      selfSigned: true,
+      key: '/custom/key.pem',
+      cert: '/custom/cert.pem',
+    });
+  });
+});

--- a/src/tools/config-ui.ts
+++ b/src/tools/config-ui.ts
@@ -1,0 +1,127 @@
+import { readFileSync } from 'fs';
+import path from 'path';
+
+export type ConfigUiSsl = {
+  key?: string,
+  cert?: string,
+  pfx?: string,
+  passphrase?: string,
+  selfSigned?: boolean,
+};
+
+export type ConfigUiSettings = {
+  language?: string,
+  ssl?: ConfigUiSsl,
+};
+
+const SSL_STRING_KEYS = ['key', 'cert', 'pfx', 'passphrase'] as const;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isPlatformEntry(value: unknown): value is Record<string, unknown> {
+  return isRecord(value) && typeof value.platform === 'string';
+}
+
+function isConfigUiPlatform(value: unknown): value is Record<string, unknown> {
+  return isPlatformEntry(value) && value.platform === 'config';
+}
+
+function slimSsl(value: unknown): ConfigUiSsl | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  const ssl: ConfigUiSsl = {};
+  for (const key of SSL_STRING_KEYS) {
+    if (typeof value[key] === 'string') {
+      ssl[key] = value[key];
+    }
+  }
+
+  if (typeof value.selfSigned === 'boolean') {
+    ssl.selfSigned = value.selfSigned;
+  }
+
+  return Object.keys(ssl).length > 0 ? ssl : undefined;
+}
+
+function slimPlatform(value: Record<string, unknown>): Record<string, unknown> {
+  if (value.platform !== 'config') {
+    return { platform: value.platform };
+  }
+
+  return {
+    platform: 'config',
+    lang: value.lang,
+    ssl: slimSsl(value.ssl),
+  };
+}
+
+function slimHomebridgeConfig(key: string, value: unknown): unknown {
+  if (isPlatformEntry(value)) {
+    return slimPlatform(value);
+  }
+
+  // Keep platforms only. Bridge PIN, accessory secrets, and other root keys must not stay in memory.
+  if (key === '' && isRecord(value)) {
+    return { platforms: Array.isArray(value.platforms) ? value.platforms : [] };
+  }
+
+  return value;
+}
+
+export function extractConfigUiSettings(raw: string): ConfigUiSettings {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw, slimHomebridgeConfig);
+  } catch {
+    return {};
+  }
+
+  if (!isRecord(parsed) || !Array.isArray(parsed.platforms)) {
+    return {};
+  }
+
+  const configUi = parsed.platforms.find(isConfigUiPlatform);
+  if (configUi === undefined) {
+    return {};
+  }
+
+  const settings: ConfigUiSettings = {};
+  if (typeof configUi.lang === 'string') {
+    settings.language = configUi.lang;
+  }
+
+  const ssl = slimSsl(configUi.ssl);
+  if (ssl !== undefined) {
+    settings.ssl = ssl;
+  }
+
+  return settings;
+}
+
+export function readConfigUiSettings(configPath: string): ConfigUiSettings {
+  try {
+    return extractConfigUiSettings(readFileSync(configPath, { encoding: 'utf8' }));
+  } catch {
+    return {};
+  }
+}
+
+export function resolveConfigUiSsl(ssl: ConfigUiSsl | undefined, configPath: string): ConfigUiSsl | undefined {
+  if (ssl === undefined) {
+    return undefined;
+  }
+
+  if (ssl.selfSigned !== true) {
+    return ssl;
+  }
+
+  return {
+    ...ssl,
+    key: ssl.key ?? path.join(configPath, '../ssl-certs/private-key.pem'),
+    cert: ssl.cert ?? path.join(configPath, '../ssl-certs/certificate.pem'),
+  };
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,6 +25,7 @@
   "exclude": [
     "eslint.config.ts",
     "node_modules",
-    "src/homebridge-ui/ui.ts"
+    "src/homebridge-ui/ui.ts",
+    "src/**/*.test.ts"
   ]
 }


### PR DESCRIPTION
## Summary
- Dummy only needs Config UI language and optional webhook SSL. It was `JSON.parse`ing the whole Homebridge `config.json`, which also holds other plugins' credentials and the bridge PIN.
- Read the file once, keep those Config UI fields, and drop the rest (including other platforms) before anything else uses the result.
- Language and SSL inheritance stay the same. Dummy webhook SSL still overrides Config UI SSL when set.

## Test plan
- [x] `npm test` (covers extract, missing file, SSL path defaults, and that other secrets are not kept)
- [x] `tsc --noEmit`
- [ ] Install the branch on a Homebridge host with Config UI language set to a non-English locale and confirm Dummy logs still use that language
- [ ] Enable a Dummy webhook with Config UI self-signed SSL and confirm HTTPS still starts
- [ ] Enable a Dummy webhook with Dummy-specific `key`/`cert` and confirm those still override Config UI SSL